### PR TITLE
Add assembly-repl

### DIFF
--- a/_software.md
+++ b/_software.md
@@ -522,6 +522,7 @@ See also [Data & Format Reversing](_format.md).
 ## Misc
 
 - [bingrep](https://github.com/m4b/bingrep) - grep through binaries
+- [Assembly REPL](https://github.com/pirate/assembly-repl) - native raw assembly, LLVM IR, C, C++, and Objective-C REPLs for macOS and Linux.
 
 - - - 
 


### PR DESCRIPTION
Adds assembly-repl, a small native assembly/LLVM IR/C/C++/Objective-C REPL for macOS and Linux. I placed it in Misc; happy to adjust if another section fits better.